### PR TITLE
Pass build tests, add support for success state (+ DMN)

### DIFF
--- a/src/Omnipay/Gate2shop/Gateway.php
+++ b/src/Omnipay/Gate2shop/Gateway.php
@@ -4,7 +4,6 @@ namespace Omnipay\Gate2shop;
 
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Gate2shop\Message\PurchaseRequest;
-use Omnipay\Gate2shop\Message\CompletePurchaseRequest;
 
 /**
  * Gate2shop Gateway
@@ -23,7 +22,8 @@ class Gateway extends AbstractGateway
         return array(
             'merchantSiteId' => '',
             'merchantId'     => '',
-            'secretKey'      => ''
+            'secretKey'      => '',
+            'customSiteName' => ''
         );
     }
 
@@ -57,13 +57,18 @@ class Gateway extends AbstractGateway
         return $this->setParameter('secretKey', $value);
     }
 
+    public function getCustomSiteName()
+    {
+        return $this->getParameter('customSiteName');
+    }
+
+    public function setCustomSiteName($value)
+    {
+        return $this->setParameter('customSiteName', $value);
+    }
+
     public function purchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Gate2shop\Message\PurchaseRequest', $parameters);
-    }
-
-    public function completePurchase(array $parameters = array())
-    {
-        return $this->createRequest('\Omnipay\Gate2shop\Message\CompletePurchaseRequest', $parameters);
     }
 }

--- a/src/Omnipay/Gate2shop/Gateway.php
+++ b/src/Omnipay/Gate2shop/Gateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\Gate2shop;
 
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Gate2shop\Message\PurchaseRequest;
+use Omnipay\Gate2shop\Message\CompletePurchaseRequest;
 
 /**
  * Gate2shop Gateway
@@ -70,5 +71,10 @@ class Gateway extends AbstractGateway
     public function purchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Gate2shop\Message\PurchaseRequest', $parameters);
+    }
+
+    public function completePurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Gate2shop\Message\CompletePurchaseRequest', $parameters);
     }
 }

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -245,8 +245,9 @@ class CompletePurchaseRequest extends PurchaseRequest
         $checksum .= $this->getPPPTransactionId();
         $checksum .= $this->getStatus();
 
-        if (!empty($this->getProductId())) {
-            $checksum .= $this->getProductId();
+        $productId = $this->getProductId();
+        if (!empty($productId)) {
+            $checksum .= $productId;
         } else {
             foreach ($this->getItems() as $item) {
                 $checksum .= $item->getName();

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -4,7 +4,6 @@ namespace Omnipay\Gate2shop\Message;
 
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\Gate2shop\Message\PurchaseRequest;
 
 /**
  * Gate2shop Complete Purchase Request
@@ -62,21 +61,6 @@ class CompletePurchaseRequest extends PurchaseRequest
 
     public function createAdvanceResponseChecksum()
     {
-        /*
-        To create a DMN response checksum:
-            1. Concatenate the following parameters in the exact order listed below:
-                a. Your secret key
-                b. From the DMN callback:
-                    * totalAmount
-                    * Currency
-                    * responseTimeStamp
-                    * PPP_TransactionID
-                    * Status
-                    * productId (If this parameter was not sent to Gate2Shop, then [Gate2shop will] concatenate all item names)
-            2. Use MD5 hash on the result string of the concatenation. Use encoding passed to the PPP
-               from the vendor site to create the MD5 hash. The default encoding is UTF-8 (unless the
-               encoding PP input parameter specifies otherwise).
-        */
         $checksum = '';
 
         $checksum .= $this->getSecretKey();
@@ -85,6 +69,9 @@ class CompletePurchaseRequest extends PurchaseRequest
         $checksum .= $this->httpRequest->query->get('responseTimeStamp');
         $checksum .= $this->httpRequest->query->get('PPP_TransactionID');
         $checksum .= $this->httpRequest->query->get('Status');
+
+        // If this parameter was not sent to Gate2shop, then
+	    // [Gate2shop will] concatenate all item names.
         $checksum .= $this->httpRequest->query->get('productId');
         
         return md5($checksum);

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -19,7 +19,6 @@ class CompletePurchaseRequest extends PurchaseRequest
         // Build a list of supplied items, as it's not handled very nicely;
         // we don't know how many items are provided, so we have to bruteforce it.
         $items = array();
-        $n = 1;
         for ($n = 1; $this->httpRequest->get("item_name_$n"); ++$n) {
             $item = array(
                 // The only two mandatory fields are item_name_X & item_amount_X.

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -71,7 +71,7 @@ class CompletePurchaseRequest extends PurchaseRequest
         $checksum .= $this->httpRequest->query->get('Status');
 
         // If this parameter was not sent to Gate2shop, then
-	    // [Gate2shop will] concatenate all item names.
+        // [Gate2shop will] concatenate all item names.
         $checksum .= $this->httpRequest->query->get('productId');
         
         return md5($checksum);

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -94,7 +94,6 @@ class CompletePurchaseRequest extends PurchaseRequest
             $checksum .= $productId;
         } else {
             // We don't know how many items are provided, so we have to bruteforce it.
-            $itemNames = '';
             for ($n = 1;; ++$n) {
                 $itemName = $this->httpRequest->query->get("item_name_$n");
                 if ($itemName === null) {
@@ -103,7 +102,7 @@ class CompletePurchaseRequest extends PurchaseRequest
 
                 // Enforce the existence of the two mandatory item fields.
                 $this->httpGetValidate("item_name_$n", "item_amount_$n");
-                $itemNames .= $itemName;
+                $checksum .= $itemName;
             }
         }
         

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -95,10 +95,11 @@ class CompletePurchaseRequest extends PurchaseRequest
         } else {
             // We don't know how many items are provided, so we have to bruteforce it.
             $itemNames = '';
-            for ($n = 1; ; ++$n) {
+            for ($n = 1;; ++$n) {
                 $itemName = $this->httpRequest->query->get("item_name_$n");
-                if ($itemName === null)
+                if ($itemName === null) {
                     break;
+                }
 
                 // Enforce the existence of the two mandatory item fields.
                 $this->httpGetValidate("item_name_$n", "item_amount_$n");

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Omnipay\Gate2shop\Message;
+use Omnipay\Common\Exception\InvalidResponseException;
+
+/**
+ * Gate2shop Complete Purchase Request
+ */
+class CompletePurchaseRequest extends PurchaseRequest
+{
+    public function getData()
+    {
+        // Mandatory fields.
+        $this->validate(
+            'ppp_status', 'PPP_TransactionID', 'totalAmount', 'currency', 'responsechecksum', 'advanceresponsechecksum',
+            'merchant_site_id', 'requestVersion', 'message', 'payment_method', 'merchant_id', 'responseTimeStamp',
+            'dynamicDescriptor', 'clientIp',
+            'item_name_1', 'item_amount_1',
+            // Not officially deemed mandatory, but required as part of the checksum.
+            'Status');
+            
+        $expectedChecksum = $this->createAdvanceResponseChecksum();
+        if ($this->getAdvanceResponseChecksum() !== $expectedChecksum) {
+            throw new InvalidResponseException('Invalid advanceResponseChecksum');
+        }
+
+        return $this->httpRequest->request->all();
+    }
+
+    public function getResponseChecksum()
+    {
+        return $this->getParameter('responsechecksum');
+    }
+    
+    public function setResponseChecksum($value)
+    {
+        return $this->setParameter('responsechecksum', $value);
+    }
+    
+    public function getAdvanceResponseChecksum()
+    {
+        return $this->getParameter('advanceresponsechecksum');
+    }
+
+    public function setAdvanceResponseChecksum($value)
+    {
+        return $this->setParameter('advanceresponsechecksum', $value);
+    }
+    
+    public function getResponseTimestamp()
+    {
+        return $this->getParameter('responseTimeStamp');
+    }
+
+    public function setResponseTimestamp($value)
+    {
+        return $this->setParameter('responseTimeStamp', $value);
+    }
+
+    public function getPPP_TransactionID()
+    {
+        return $this->getParameter('PPP_TransactionID');
+    }
+    
+    public function setPPP_TransactionID($value)
+    {
+        return $this->setParameter('PPP_TransactionID', $value);
+    }
+    
+    public function getPPPStatus()
+    {
+        return $this->getParameter('ppp_status');
+    }
+    
+    public function setPPPStatus($value)
+    {
+        return $this->setParameter('ppp_status', $value);
+    }
+
+    public function getStatus()
+    {
+        return $this->getParameter('Status');
+    }
+    
+    public function setStatus($value)
+    {
+        return $this->setParameter('Status', $value);
+    }
+
+    public function getProductId()
+    {
+        return $this->getParameter('productId');
+    }
+
+    public function setProductId($value)
+    {
+        return $this->setParameter('productId', $value);
+    }
+    
+    public function getTotalAmount()
+    {
+        return $this->getParameter('totalAmount');
+    }
+    
+    public function setTotalAmount($value)
+    {
+        return $this->setParameter('totalAmount', $value);
+    }
+    
+    public function getMerchantSiteId()
+    {
+        return $this->getParameter('merchant_site_id');
+    }
+    
+    public function setMerchantSiteId($value)
+    {
+        return $this->setParameter('merchant_site_id', $value);
+    }
+    
+    public function getRequestVersion()
+    {
+        return $this->getParameter('requestVersion');
+    }
+    
+    public function setRequestVersion($value)
+    {
+        return $this->setParameter('requestVersion', $value);
+    }
+    
+    public function getMessage()
+    {
+        return $this->getParameter('message');
+    }
+    
+    public function setMessage($value)
+    {
+        return $this->setParameter('message', $value);
+    }
+    
+    public function getPaymentMethod()
+    {
+        return $this->getParameter('payment_method');
+    }
+    
+    public function setPaymentMethod($value)
+    {
+        return $this->setParameter('payment_method', $value);
+    }
+    
+    public function getMerchantID()
+    {
+        return $this->getParameter('merchant_id');
+    }
+    
+    public function setMerchantID($value)
+    {
+        return $this->setParameter('merchant_id', $value);
+    }
+    
+    public function getDynamicDescriptor()
+    {
+        return $this->getParameter('dynamicDescriptor');
+    }
+    
+    public function setDynamicDescriptor($value)
+    {
+        return $this->setParameter('dynamicDescriptor', $value);
+    }
+
+    public function createAdvanceResponseChecksum()
+    {
+        /*
+        To create a DMN response checksum:
+            1. Concatenate the following parameters in the exact order listed below:
+                a. Your secret key
+                b. From the DMN callback:
+                    * totalAmount
+                    * Currency
+                    * responseTimeStamp
+                    * PPP_TransactionID
+                    * Status
+                    * productId (If this parameter was not sent to Gate2Shop, then concatenate all item names)
+            2. Use MD5 hash on the result string of the concatenation. Use encoding passed to the PPP
+               from the vendor site to create the MD5 hash. The default encoding is UTF-8 (unless the
+               encoding PP input parameter specifies otherwise).
+        */
+        $checksum = '';
+
+        $checksum .= $this->getSecretKey();
+        $checksum .= $this->getTotalAmount();
+        $checksum .= $this->getCurrency();
+        $checksum .= $this->getResponseTimestamp();
+        $checksum .= $this->getPPP_TransactionID();
+        $checksum .= $this->getStatus();
+
+        if (!empty($this->getProductId())) {
+            $checksum .= $this->getProductId();
+        } else {
+            foreach ($this->getItems() as $item) {
+                $checksum .= $item->getName();
+            }
+        }
+        
+        return md5($checksum);
+    }
+
+    public function sendData($data)
+    {
+        return $this->response = new CompletePurchaseResponse($this, $data);
+    }
+}

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseRequest.php
@@ -21,7 +21,7 @@ class CompletePurchaseRequest extends PurchaseRequest
         $items = array();
         $n = 1;
         for ($n = 1; $this->httpRequest->get("item_name_$n"); ++$n) {
-            $item = [
+            $item = array(
                 // The only two mandatory fields are item_name_X & item_amount_X.
                 'name' => $this->httpRequest->get("item_name_$n"),
                 'amount' => $this->httpRequest->get("item_amount_$n"),
@@ -30,7 +30,7 @@ class CompletePurchaseRequest extends PurchaseRequest
                 'discount' => $this->httpRequest->get("item_discount_$n"),
                 'handling' => $this->httpRequest->get("item_handling_$n"),
                 'shipping' => $this->httpRequest->get("item_shipping_$n"),
-            ];
+            );
 
             // Enforce the existing of mandatory fields.
             if (empty($item['name'])) {

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
@@ -11,6 +11,6 @@ class CompletePurchaseResponse extends AbstractResponse
 {
     public function isSuccessful()
     {
-        return true;
+        return $this->data['ppp_status'] === 'OK';
     }
 }

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
@@ -18,32 +18,27 @@ class CompletePurchaseResponse extends AbstractResponse
     {
         // message & Error fields are generic enough to be useless for most cases.
         // Reason, however, consistently provides more informative messages.
-        if (isset($this->data['Reason']))
-            return $this->data['Reason'];
+        return isset($this->data['Reason']) ? $this->data['Reason'] : null;
     }
 
     public function getCode()
     {
         // OK, PENDING, or FAIL.
-        if (isset($this->data['ppp_status']))
-            return $this->data['ppp_status'];
+        return isset($this->data['ppp_status']) ? $this->data['ppp_status'] : null;
     }
 
     public function getErrCode()
     {
-        if (isset($this->data['ErrCode']))
-            return $this->data['ErrCode'];
+        return isset($this->data['ErrCode']) ? $this->data['ErrCode'] : null;
     }
 
     public function getExErrCode()
     {
-        if (isset($this->data['ExErrCode']))
-            return $this->data['ExErrCode'];
+        return isset($this->data['ExErrCode']) ? $this->data['ExErrCode'] : null;
     }
 
     public function getTransactionReference()
     {
-        if (isset($this->data['PPP_TransactionID']))
-            return $this->data['PPP_TransactionID'];
+        return isset($this->data['PPP_TransactionID']) ? $this->data['PPP_TransactionID'] : null;
     }
 }

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Omnipay\Gate2shop\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+
+/**
+ *  Gate2shop Complete Purchase Response
+ */
+class CompletePurchaseResponse extends AbstractResponse
+{
+    public function isSuccessful()
+    {
+        return true;
+    }
+}

--- a/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Gate2shop/Message/CompletePurchaseResponse.php
@@ -11,6 +11,39 @@ class CompletePurchaseResponse extends AbstractResponse
 {
     public function isSuccessful()
     {
-        return $this->data['ppp_status'] === 'OK';
+        return $this->getErrCode() === '0';
+    }
+
+    public function getMessage()
+    {
+        // message & Error fields are generic enough to be useless for most cases.
+        // Reason, however, consistently provides more informative messages.
+        if (isset($this->data['Reason']))
+            return $this->data['Reason'];
+    }
+
+    public function getCode()
+    {
+        // OK, PENDING, or FAIL.
+        if (isset($this->data['ppp_status']))
+            return $this->data['ppp_status'];
+    }
+
+    public function getErrCode()
+    {
+        if (isset($this->data['ErrCode']))
+            return $this->data['ErrCode'];
+    }
+
+    public function getExErrCode()
+    {
+        if (isset($this->data['ExErrCode']))
+            return $this->data['ExErrCode'];
+    }
+
+    public function getTransactionReference()
+    {
+        if (isset($this->data['PPP_TransactionID']))
+            return $this->data['PPP_TransactionID'];
     }
 }

--- a/src/Omnipay/Gate2shop/Message/PurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/PurchaseRequest.php
@@ -85,7 +85,7 @@ class PurchaseRequest extends AbstractRequest
 
     public function getMerchantLocale()
     {
-        $merchantLocales = [
+        $merchantLocales = array(
             'en'    => 'en_US',
             'it'    => 'it_IT',
             'es'    => 'Es_ES',
@@ -108,7 +108,7 @@ class PurchaseRequest extends AbstractRequest
             'sr'    => 'sr_RS',
             'hr'    => 'hr_HR',
             'ro'    => 'ro_RO'
-        ];
+        );
 
         return (isset($merchantLocales[$this->getParameter('merchantLocale')])) ?
             $merchantLocales[$this->getParameter('merchantLocale')] :

--- a/src/Omnipay/Gate2shop/Message/PurchaseRequest.php
+++ b/src/Omnipay/Gate2shop/Message/PurchaseRequest.php
@@ -26,7 +26,7 @@ class PurchaseRequest extends AbstractRequest
 
     public function getTimestamp()
     {
-        return date("Y-m-d.h:i:s");
+        return date('Y-m-d.h:i:s');
     }
 
     public function getMerchantSiteId()

--- a/tests/Omnipay/Gate2shop/GatewayTest.php
+++ b/tests/Omnipay/Gate2shop/GatewayTest.php
@@ -31,7 +31,7 @@ class GatewayTest extends GatewayTestCase
 
     public function testPurchase()
     {
-        $request = $this->gateway->purchase($this->options)->send();
+        $response = $this->gateway->purchase($this->options)->send();
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());

--- a/tests/Omnipay/Gate2shop/GatewayTest.php
+++ b/tests/Omnipay/Gate2shop/GatewayTest.php
@@ -16,17 +16,17 @@ class GatewayTest extends GatewayTestCase
         $this->gateway->setMerchantSiteId('');
         $this->gateway->setSecretKey('');
 
-        $this->options = [
+        $this->options = array(
             'currency'  => 'USD',
-            'items'     => [
-                ['name' => 'Item Name 1', 'quantity' => 1, 'price' => '5'],
-                ['name' => 'Item Name 2', 'quantity' => 1, 'price' => '5']
-            ],
-            'customfields' => [
-                ['name' => 'customField1', 'value' => 'customField1 value'],
-                ['name' => 'customField2', 'value' => 'customField2 value']
-            ]
-        ];
+            'items'     => array(
+                array('name' => 'Item Name 1', 'quantity' => 1, 'price' => '5'),
+                array('name' => 'Item Name 2', 'quantity' => 1, 'price' => '5')
+            ),
+            'customfields' => array(
+                array('name' => 'customField1', 'value' => 'customField1 value'),
+                array('name' => 'customField2', 'value' => 'customField2 value')
+            )
+        );
     }
 
     public function testPurchase()


### PR DESCRIPTION
Needed to make use of the API, so I tried to continue where you left off.

Not having used Omnipay before was a little bit of a struggle to figure out how things were supposed to work (apparently notifications can _only_ really work via the completePurchase()/completeAuthorize() methods), so apologies if anything's off in that regard.

The pull request doesn't really focus on anything too specific, but I:
- fixed the initial test failing because of the incorrect variable name.
- fixed PHP 5.3 builds (was just the new PHP 5.4 array syntax).
- added support for the custom site name to be supplied by the gateway config. I'm not 100% sure if this is how it should work being that it's only technically used by PurchaseRequests, but it makes sense to me to be able to define that generically with the rest of the gateway config.
- added support for success responses, and consequently DMN notifications (since they're handled the same way).

Other than cursory testing, and build tests (which I, regretfully, haven't yet added to), I haven't been able to more thoroughly test the full payment process, but according to Gate2Shop's documentation it _should_ be fine. It's definitely still in an experimental state.

The main concerns I have with this are:
- dealing with the request data directly (it seems simpler to do this, but breaks class encapsulation. Not doing this means introducing a great deal of setters for no real reason -- unless I'm missing something -- and then still having to workaround edge cases that the code style requirement doesn't like). This doesn't seem to be a problem with cases like 2Checkout, though it uses the POST request data. I haven't seen any use the GET request data, as in this case. The entire thing just seems unwarranted, but I have no idea how you'd pull in parameters dynamically (like item_name_X -- you'd need setters for each of them _anyway_ to use them as with everything else).
- in addition to the above, my horribly placed utility method for validating the existence of these GET parameters... it really shouldn't be in the scope of that class, but even its (presently required) existence is worrisome.

Again, I'm not really familiar with the Omnipay, so hopefully there's better ways to address these concerns.
